### PR TITLE
Add strict prototype requirements

### DIFF
--- a/kernel/arch/arm/Makefile
+++ b/kernel/arch/arm/Makefile
@@ -15,12 +15,6 @@ CFLAGS		+=-ffixed-r8
 AFLAGS		+=
 LDFLAGS_ewokos	:=--gc-sections -p --no-undefined -X
 
-CFLAGS		+=\
-	-pedantic -Wall -Wextra -msoft-float -fPIC -mapcs-frame \
-	-fno-builtin-printf -fno-builtin-strcpy -Wno-overlength-strings \
-	-fno-builtin-exit -fno-builtin-stdio \
-	-std=c99
-
 # Never generate .eh_frame
 CFLAGS		+= $(call cc-option,-fno-dwarf2-cfi-asm)
 
@@ -29,6 +23,9 @@ KBUILD_DEFCONFIG := versatilepb_defconfig
 
 ifeq ($(CONFIG_FRAME_POINTER),y)
 CFLAGS		+=-fno-omit-frame-pointer -mapcs -mno-sched-prolog
+endif
+ifeq ($(CONFIG_CC_GEN_EXTRA_WARNINGS),y)
+CFLAGS		+=-Wextra -Wstrict-prototypes -Wmissing-prototypes
 endif
 
 ifeq ($(CONFIG_CPU_BIG_ENDIAN),y)

--- a/kernel/init/Kconfig
+++ b/kernel/init/Kconfig
@@ -52,6 +52,9 @@ config CC_GEN_DEBUG
 	  development and want to debug, answer Y.
 	  Most people should answer N.
 
+config CC_GEN_EXTRA_WARNINGS
+	bool "Compile with extra warnings"
+
 endif
 
 endmenu


### PR DESCRIPTION
Some issues can be avoided by enforcing prototype definitions.
This patch adds an option to allow detection of such issues.

Signed-off-by: Lv Zheng <zhenglv@hotmail.com>