### PR TITLE
Fix CONFIG_KEYMAP2 enabling

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -241,6 +241,7 @@ include $(srctree)/scripts/Kbuild.include
 # Use TARGETINCLUDE when you must reference the include/ directory.
 # Needed to be compatible with the O= option
 TARGETINCLUDE   := -Iinclude -Iinclude/std \
+                   -include $(srctree)/include/target/config.h \
                    $(if $(KBUILD_SRC),-Iinclude2 -I$(srctree)/include)
 
 # Make variables (CC, etc...)


### PR DESCRIPTION
The config.h was not included by all files, this patch fixes it
to enable CONFIG_KEYMAP2 configuration.

Signed-off-by: Lv Zheng <zhenglv@hotmail.com>