### PR TITLE
rootfs: disable all builtins from gcc

### DIFF
--- a/rootfs/Makefile
+++ b/rootfs/Makefile
@@ -17,15 +17,16 @@ COMMON_OBJ=$(COMMON_LIB)/lib/kstring.o \
 
 # flags
 CFLAGS = -I. -O2 \
-			   -Wstrict-prototypes \
-				 -I ../lib/include \
-				 -I lib/include \
-				 -I $(COMMON_LIB)/include \
-				 -marm \
-				 -pedantic -Wall -Wextra -msoft-float -fPIC -mapcs-frame \
-         -fno-builtin-printf -fno-builtin-strcpy -Wno-overlength-strings \
-         -fno-builtin-exit -fno-builtin-stdio \
-				 -std=c99 
+	-Wstrict-prototypes \
+	-I ../lib/include \
+	-I lib/include \
+	-I $(COMMON_LIB)/include \
+	-marm \
+	-pedantic -Wall -Wextra -msoft-float -fPIC -mapcs-frame \
+	-Wno-overlength-strings \
+	-fno-builtin \
+	-std=c99
+
 LDFLAGS = -lgcc
 
 #ASFLAGS = -g -I $(KERNEL_LIB)/include


### PR DESCRIPTION
Fixed issue #12: Failed to build rootfs under Ubuntu 18.04

Add -fno-builtin-malloc to CFLAGS is enough, but it's better
to disable all builtins, while the rootfs is an independent
routine which has nothing depends on gcc/libc.